### PR TITLE
Fix career consultation option values

### DIFF
--- a/frontend/devforabuck-web/src/app/pages/admin/component/slot-manager/slot-manager.html
+++ b/frontend/devforabuck-web/src/app/pages/admin/component/slot-manager/slot-manager.html
@@ -39,7 +39,7 @@
             class="form-select"
           >
             <option value="resume">Resume Review</option>
-            <option value="careercouncil">Career Consultation</option>
+            <option value="careercounsel">Career Consultation</option>
           </select>
         </div>
 
@@ -69,7 +69,7 @@
           >
             <option value="">All Types</option>
             <option value="resume">Resume Review</option>
-            <option value="careercouncil">Career Consultation</option>
+            <option value="careercounsel">Career Consultation</option>
           </select>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fix career consultation option values in slot manager

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0ab39504832ca88a40520ca2adfb