### PR TITLE
feat: guard bookings page behind auth

### DIFF
--- a/frontend/devforabuck-web/src/app/pages/bookings/bookings.ts
+++ b/frontend/devforabuck-web/src/app/pages/bookings/bookings.ts
@@ -8,6 +8,7 @@ import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { BookingsService, BookingList } from '../../service/bookings-service';
 import { BookingModalComponent } from '../components/modal/create-booking/create-booking';
+import { AuthService } from '../../shared/services/auth.service';
 // import { BookingModalComponent } from '../booking-modal/create-booking.component';
 
 @Component({
@@ -36,11 +37,10 @@ export class Bookings implements OnInit {
 
   private bookingsService = inject(BookingsService);
   private dialog = inject(MatDialog);
-  // Replace with real auth if needed
-  private isLoggedIn = true;
+  private auth = inject(AuthService);
 
   ngOnInit(): void {
-    if (this.isLoggedIn) {
+    if (this.auth.isLoggedIn) {
       this.loadBookings();
     } else {
       this.notAllowed = true;
@@ -49,6 +49,11 @@ export class Bookings implements OnInit {
   }
 
   loadBookings(): void {
+    if (!this.auth.isLoggedIn) {
+      this.notAllowed = true;
+      this.isLoading = false;
+      return;
+    }
     this.isLoading = true;
     this.error = null;
 


### PR DESCRIPTION
## Summary
- inject AuthService into bookings page and remove placeholder flag
- only load bookings when authenticated and guard loadBookings for safety

## Testing
- `npm test -- --watch=false` (fails: No binary for Chrome browser on your platform)

------
https://chatgpt.com/codex/tasks/task_e_68aa0cb9cf80832c85c326553aa83218