### PR TITLE
docs: add local setup note for frontend dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ A full-stack booking and consultation platform built with <b>ASP.NET Core (.NET 
   /Domain         # Entities, Aggregates
   /Infrastructure # Cosmos DB, Blob Storage, Auth setup
 
+## ⚙️ Local Setup
+After pulling the repository, install frontend dependencies:
+```bash
+cd frontend/devforabuck-web
+npm install
+```
+This restores the `node_modules` folder, which is intentionally excluded from version control.
+
 ## 🔐 Authentication Flow
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
## Summary
- document frontend dependency installation steps since node_modules is ignored

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0e1c49e8832c8acff8549dc59356