### PR TITLE
docs: close mermaid block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,5 @@ sequenceDiagram
   Frontend->>Backend: Exchange code for tokens
   Backend->>Frontend: Access token + ID token
   Frontend->>Backend: Make secure API calls
-
+```
 


### PR DESCRIPTION
## Summary
- close the final Mermaid diagram in the README to restore proper markdown rendering

## Testing
- `npm test -- --watch=false --browsers=ChromiumHeadless` *(fails: Chromium snap not installed)*
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68aa0e1fcc90832c8b07414714c95e3c