### PR TITLE
Use async for slot retrieval

### DIFF
--- a/backend/DevForABuck.Application/Queries/GetAllSlotsHandler.cs
+++ b/backend/DevForABuck.Application/Queries/GetAllSlotsHandler.cs
@@ -13,17 +13,9 @@ public class GetAllSlotsHandler: IRequestHandler<GetAllSlots, IEnumerable<Availa
         _slotService = slotService;
     }
     
-    public Task<IEnumerable<AvailableSlot>> Handle(GetAllSlots request, CancellationToken cancellationToken)
+    public async Task<IEnumerable<AvailableSlot>> Handle(GetAllSlots request, CancellationToken cancellationToken)
     {
-        try
-        {
-            var allSlots = _slotService.GetAllSlotsAsync();
-            return allSlots;
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e);
-            throw;
-        }
+        var allSlots = await _slotService.GetAllSlotsAsync();
+        return allSlots;
     }
 }


### PR DESCRIPTION
## Summary
- mark `GetAllSlotsHandler` as `async` and await slot service

## Testing
- `dotnet test backend/DevForABuck.sln`

------
https://chatgpt.com/codex/tasks/task_e_68aa0e4049ec832cb7a58b407da03e4f