### PR TITLE
feat: protect admin route with guard

### DIFF
--- a/frontend/devforabuck-web/src/app/app.routes.ts
+++ b/frontend/devforabuck-web/src/app/app.routes.ts
@@ -4,11 +4,11 @@ import { About } from './pages/about/about';
 import { Contact } from './pages/contact/contact';
 import { Bookings } from './pages/bookings/bookings';
 import { Admin } from './pages/admin/admin';
+import { AdminGuard } from './shared/guard/admin-guard';
 export const routes: Routes = [
   { path: '', component: Home },
   { path: 'about', component: About },
   { path: 'contact', component: Contact },
   { path: 'bookings', component: Bookings },
-  // TODO: add guard later
-  { path: 'admin', component: Admin },
+  { path: 'admin', component: Admin, canActivate: [AdminGuard] },
 ];

--- a/frontend/devforabuck-web/src/app/shared/guard/admin-guard.ts
+++ b/frontend/devforabuck-web/src/app/shared/guard/admin-guard.ts
@@ -1,27 +1,22 @@
-import { Injectable } from '@angular/core';
-import { CanActivate, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
 
-@Injectable({
-  providedIn: 'root',
-})
-export class AdminGuard implements CanActivate {
-  constructor(private router: Router) {}
-
-  canActivate(): boolean {
-    const token = localStorage.getItem('access_token');
-    if (!token) {
-      this.router.navigate(['/']);
-      return false;
-    }
-
+export const AdminGuard: CanActivateFn = () => {
+  const router = inject(Router);
+  const token = localStorage.getItem('access_token');
+  if (!token) {
+    router.navigate(['/']);
+    return false;
+  }
+  try {
     const payload = JSON.parse(atob(token.split('.')[1]));
     const roles = payload?.roles || [];
-
     if (roles.includes('Admin')) {
       return true;
     }
-
-    this.router.navigate(['/']);
-    return false;
+  } catch {
+    // ignore invalid token
   }
-}
+  router.navigate(['/']);
+  return false;
+};


### PR DESCRIPTION
## Summary
- add AdminGuard to validate access tokens and enforce admin role
- secure /admin route with AdminGuard

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0e51e7a8832c8853a719f59eb4ff