### PR TITLE
Add validation to booking creation

### DIFF
--- a/backend/DevForABuck.API/Controllers/BookingsCommandController.cs
+++ b/backend/DevForABuck.API/Controllers/BookingsCommandController.cs
@@ -18,6 +18,11 @@ public class BookingsCommandController : ControllerBase
     [Consumes("multipart/form-data")]
     public async Task<IActionResult> Create([FromForm] CreateBookingCommand command)
     {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
         var booking = await _mediator.Send(command);
         return CreatedAtAction(nameof(Create), booking);
     }

--- a/backend/DevForABuck.Application/Commands/CreateBookingCommand.cs
+++ b/backend/DevForABuck.Application/Commands/CreateBookingCommand.cs
@@ -1,16 +1,32 @@
+using System.ComponentModel.DataAnnotations;
 using DevForABuck.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Http;
+
 namespace DevForABuck.Application.Commands;
 
-public class CreateBookingCommand: IRequest<Booking>
+// TODO: Consider using FluentValidation for more complex validation rules.
+public class CreateBookingCommand : IRequest<Booking>
 {
+    [Required]
     public string Name { get; set; }
+
+    [Required]
+    [EmailAddress]
     public string Email { get; set; }
+
+    [Required]
     public string Stack { get; set; }
+
+    [Range(0, 50)]
     public int ExperienceYears { get; set; }
+
+    [Required]
     public DateTime SlotTime { get; set; }
-    
+
+    [Required]
     public string SessionType { get; set; }
+
+    [Required]
     public IFormFile Resume { get; set; }
 }


### PR DESCRIPTION
## Summary
- add data annotations to `CreateBookingCommand`
- validate model state in `BookingsCommandController`
- add note about using FluentValidation for complex rules

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68aa0e6087cc832cbaf85e9aeaae19f9