### PR TITLE
Enable role-based authorization

### DIFF
--- a/backend/DevForABuck.API/Controllers/BookingsQueryController.cs
+++ b/backend/DevForABuck.API/Controllers/BookingsQueryController.cs
@@ -1,6 +1,7 @@
 using DevForABuck.Application.Queries.GetAllBookings;
 using DevForABuck.Application.Queries.GetBookingsByEmail;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DevForABuck.API.Controllers
@@ -17,6 +18,7 @@ namespace DevForABuck.API.Controllers
         }
 
         [HttpGet("admin/all")]
+        [Authorize(Roles = "Admin")]
         public async Task<IActionResult> GetAllBookings()
         {
             var bookings = await _mediator.Send(new GetAllBookingsQuery());

--- a/backend/DevForABuck.API/Controllers/SlotsCommandController.cs
+++ b/backend/DevForABuck.API/Controllers/SlotsCommandController.cs
@@ -1,10 +1,12 @@
 using DevForABuck.Application.Commands;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DevForABuck.API.Controllers;
 [ApiController]
 [Route("api/slots/commands")]
+[Authorize(Roles = "Admin")]
 public class SlotsCommandController: ControllerBase
 {
     private readonly IMediator _mediator;

--- a/backend/DevForABuck.API/Controllers/SlotsQueryController.cs
+++ b/backend/DevForABuck.API/Controllers/SlotsQueryController.cs
@@ -1,5 +1,6 @@
 using DevForABuck.Application.Queries;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DevForABuck.API.Controllers;
@@ -15,6 +16,7 @@ public class SlotsQueryController: ControllerBase
     }
 
     [HttpGet("admin/allSlots")]
+    [Authorize(Roles = "Admin")]
     public async Task<IActionResult> GetAllSlotsAsync()
     {
         var allSlots = await _mediator.Send(new GetAllSlots());

--- a/backend/DevForABuck.API/Program.cs
+++ b/backend/DevForABuck.API/Program.cs
@@ -4,6 +4,9 @@ using Microsoft.Azure.Cosmos;
 using Azure.Storage.Blobs;
 using DevForABuck.Application.Commands.CreateBooking;
 using MediatR;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.Security.Claims;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -34,6 +37,20 @@ builder.Services.AddSingleton(s =>
 builder.Services.AddMediatR(typeof(Program));
 builder.Services.AddMediatR(typeof(CreateBookingCommandHandler).Assembly);
 
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = builder.Configuration["Auth0:Authority"];
+        options.Audience = builder.Configuration["Auth0:Audience"];
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            NameClaimType = ClaimTypes.NameIdentifier,
+            RoleClaimType = "roles"
+        };
+    });
+
+builder.Services.AddAuthorization();
+
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole(); // This connects logs to App Service Log Stream!
 
@@ -59,6 +76,7 @@ var app = builder.Build();
 app.UseRouting();
 app.UseCors("AllowFrontend");
 app.UseHttpsRedirection();
+app.UseAuthentication();
 app.UseAuthorization();
 
 // ✅ Always enable Swagger in all envs

--- a/frontend/devforabuck-web/src/app/shared/guard/admin-guard.ts
+++ b/frontend/devforabuck-web/src/app/shared/guard/admin-guard.ts
@@ -1,22 +1,15 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
 
 export const AdminGuard: CanActivateFn = () => {
   const router = inject(Router);
-  const token = localStorage.getItem('access_token');
-  if (!token) {
-    router.navigate(['/']);
-    return false;
+  const auth = inject(AuthService);
+
+  if (auth.isLoggedIn) {
+    return true;
   }
-  try {
-    const payload = JSON.parse(atob(token.split('.')[1]));
-    const roles = payload?.roles || [];
-    if (roles.includes('Admin')) {
-      return true;
-    }
-  } catch {
-    // ignore invalid token
-  }
+
   router.navigate(['/']);
   return false;
 };


### PR DESCRIPTION
## Summary
- configure JWT bearer authentication with role claims and enable authentication middleware
- require `Admin` role on slot and booking admin endpoints
- simplify admin guard to rely on login state only

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `dotnet test backend/DevForABuck.sln`


------
https://chatgpt.com/codex/tasks/task_e_68aa18db2df8832cb53edba9ca393640