### PR TITLE
Allow tokens with api scheme audience

### DIFF
--- a/backend/DevForABuck.API/Program.cs
+++ b/backend/DevForABuck.API/Program.cs
@@ -56,7 +56,11 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             ValidateIssuer = true,
             ValidIssuer = $"{authority}/{tenantId}/v2.0/",
             ValidateAudience = true,
-            ValidAudience = $"{clientId}",
+            // Azure AD can issue tokens with either the bare ClientId or an
+            // `api://{clientId}` prefix as the audience. Accept both formats so
+            // locally issued tokens and those requested with a custom scope are
+            // considered valid.
+            ValidAudiences = new[] { $"api://{clientId}", clientId },
             ValidateLifetime = true,
             RoleClaimType = "roles"
         };


### PR DESCRIPTION
## Summary
- accept Azure AD tokens whose audience uses the `api://{clientId}` prefix

## Testing
- `~/.dotnet/dotnet build backend/DevForABuck.sln`

------
https://chatgpt.com/codex/tasks/task_e_68aca3c9ffa4832cae8509bda1ca2864