### PR TITLE
feat: add auth interceptor

### DIFF
--- a/frontend/devforabuck-web/src/app/app.config.ts
+++ b/frontend/devforabuck-web/src/app/app.config.ts
@@ -2,13 +2,19 @@ import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChang
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
-import { provideHttpClient } from '@angular/common/http';
+import {
+  HTTP_INTERCEPTORS,
+  provideHttpClient,
+  withInterceptorsFromDi
+} from '@angular/common/http';
+import { AuthInterceptor } from './shared/interceptors/auth.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideHttpClient(),
+    provideHttpClient(withInterceptorsFromDi()),
+    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
     provideRouter(routes)
   ]
 };

--- a/frontend/devforabuck-web/src/app/service/bookings-service.spec.ts
+++ b/frontend/devforabuck-web/src/app/service/bookings-service.spec.ts
@@ -1,0 +1,55 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HTTP_INTERCEPTORS,
+  HttpClient
+} from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { BookingsService } from './bookings-service';
+import { AuthInterceptor } from '../shared/interceptors/auth.interceptor';
+import { environment } from '../../environments/environment';
+
+describe('BookingsService with AuthInterceptor', () => {
+  let service: BookingsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        BookingsService,
+        { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true }
+      ]
+    });
+    service = TestBed.inject(BookingsService);
+    httpMock = TestBed.inject(HttpTestingController);
+    localStorage.setItem('access_token', 'test-token');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    httpMock.verify();
+  });
+
+  it('getAllBookings should include Authorization header', () => {
+    service.getAllBookings().subscribe();
+    const req = httpMock.expectOne(`${environment.apiUrl}/bookings/queries/admin/all`);
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
+    req.flush([]);
+  });
+
+  it('getBookingsByEmail should include Authorization header', () => {
+    const email = 'test@example.com';
+    service.getBookingsByEmail(email).subscribe();
+    const req = httpMock.expectOne(`${environment.apiUrl}/bookings/queries/${email}`);
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
+    req.flush([]);
+  });
+
+  it('createBooking should include Authorization header', () => {
+    const formData = new FormData();
+    service.createBooking(formData).subscribe();
+    const req = httpMock.expectOne(`${environment.apiUrl}/bookings/commands`);
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
+    req.flush({});
+  });
+});

--- a/frontend/devforabuck-web/src/app/shared/interceptors/auth.interceptor.ts
+++ b/frontend/devforabuck-web/src/app/shared/interceptors/auth.interceptor.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  intercept(
+    req: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    const token = localStorage.getItem('access_token');
+    if (token) {
+      const authReq = req.clone({
+        setHeaders: { Authorization: `Bearer ${token}` }
+      });
+      return next.handle(authReq);
+    }
+    return next.handle(req);
+  }
+}


### PR DESCRIPTION
## Summary
- add HTTP auth interceptor to append bearer token from localStorage
- register interceptor in app config
- test bookings service requests include Authorization header

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68acb353270c832c812a9355a5b9e7f3