### PR TITLE
Log JWT auth failures

### DIFF
--- a/backend/DevForABuck.API/Program.cs
+++ b/backend/DevForABuck.API/Program.cs
@@ -66,6 +66,16 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             ValidateLifetime = true,
             RoleClaimType = "roles"
         };
+        options.Events = new JwtBearerEvents
+        {
+            OnAuthenticationFailed = ctx =>
+            {
+                var logger = ctx.HttpContext.RequestServices.GetRequiredService<ILogger<Program>>();
+                logger.LogError(ctx.Exception, "Authentication failed");
+                ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                return Task.CompletedTask;
+            }
+        };
     });
 
 builder.Services.AddAuthorization();


### PR DESCRIPTION
## Summary
- log authentication failures in JWT bearer middleware

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68acb3586de4832c993157d5863c7644