### PR TITLE
Encode email parameter in bookings service

### DIFF
--- a/frontend/devforabuck-web/src/app/service/bookings-service.ts
+++ b/frontend/devforabuck-web/src/app/service/bookings-service.ts
@@ -26,7 +26,9 @@ export class BookingsService {
   }
 
   getBookingsByEmail(email: string): Observable<BookingList[]> {
-    return this.http.get<BookingList[]>(`${this.apiUrl}/bookings/queries/${email}`);
+    return this.http.get<BookingList[]>(
+      `${this.apiUrl}/bookings/queries/${encodeURIComponent(email)}`
+    );
   }
 
   createBooking(formData: FormData): Observable<any> {


### PR DESCRIPTION
## Summary
- URL-encode email when fetching bookings by address

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68acb3566d78832ca0488f96949ee9a9