### PR TITLE
Add strongly typed auth options with validation

### DIFF
--- a/backend/DevForABuck.API/AuthOptions.cs
+++ b/backend/DevForABuck.API/AuthOptions.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DevForABuck.API;
+
+public class AuthOptions
+{
+    [Required]
+    public string? TenantId { get; init; }
+
+    [Required]
+    public string? ClientId { get; init; }
+
+    [Required]
+    public string? Authority { get; init; }
+}
+


### PR DESCRIPTION
## Summary
- add AuthOptions with required config properties
- bind and validate Auth settings
- configure JWT bearer using validated auth options

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68acb36219a8832c9e6ee212bc5d17a8