### PR TITLE
chore: include API scope in auth configuration

### DIFF
--- a/frontend/devforabuck-web/src/app/shared/services/auth.service.ts
+++ b/frontend/devforabuck-web/src/app/shared/services/auth.service.ts
@@ -56,6 +56,7 @@ export class AuthService {
     body.set('code', code);
     body.set('redirect_uri', environment.redirectUri);
     body.set('client_id', environment.clientId);
+    body.set('scope', environment.scope);
     body.set('code_verifier', codeVerifier || '');
 
     try {

--- a/frontend/devforabuck-web/src/environments/environment.dev.ts
+++ b/frontend/devforabuck-web/src/environments/environment.dev.ts
@@ -6,5 +6,5 @@ export const environment = {
   authority: 'https://devforabucklocal.ciamlogin.com',
   redirectUri: 'https://dev.devforabuck.com',
   logoutRedirectUri: 'https://dev.devforabuck.com',
-  scope: 'openid profile'
+  scope: 'openid profile api://5df26c43-eac1-441f-9114-1961a2d0b26d/.default'
 };

--- a/frontend/devforabuck-web/src/environments/environment.prod.ts
+++ b/frontend/devforabuck-web/src/environments/environment.prod.ts
@@ -6,5 +6,5 @@ export const environment = {
   authority: 'https://devforabuck.ciamlogin.com',
   redirectUri: 'https://www.devforabuck.com',
   logoutRedirectUri: 'https://www.devforabuck.com',
-  scope: 'openid profile'
+  scope: 'openid profile api://16739f71-1bdc-4368-8b94-a79bf5573b83/.default'
 };

--- a/frontend/devforabuck-web/src/environments/environment.ts
+++ b/frontend/devforabuck-web/src/environments/environment.ts
@@ -6,5 +6,5 @@ export const environment = {
   authority: 'https://devforabucklocal.ciamlogin.com',
   redirectUri: 'http://localhost:4200',
   logoutRedirectUri: 'http://localhost:4200',
-  scope: 'openid profile api://5df26c43-eac1-441f-9114-1961a2d0b26d/access_as_user'
+  scope: 'openid profile api://5df26c43-eac1-441f-9114-1961a2d0b26d/.default'
 };


### PR DESCRIPTION
## Summary
- include API scope in all environment configs
- send scope in auth token exchange

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `curl -v -X POST "https://devforabucklocal.ciamlogin.com/devforabucklocal.onmicrosoft.com/oauth2/v2.0/token" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=5df26c43-eac1-441f-9114-1961a2d0b26d&scope=api://5df26c43-eac1-441f-9114-1961a2d0b26d/.default&grant_type=client_credentials&client_secret=PLACEHOLDER" *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68acb36a4a70832ca41f5924051549db