### PR TITLE
Allow all origins for CORS

### DIFF
--- a/backend/DevForABuck.API/Program.cs
+++ b/backend/DevForABuck.API/Program.cs
@@ -92,18 +92,16 @@ builder.Services.AddAuthorization();
 
 
 
-// Cors policy
+// CORS policy
+// Using AllowAnyOrigin so the API can be accessed from any frontend.
+// This is useful for development or when the frontend's domain isn't known at build time.
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowFrontend", policy =>
-    {
-        policy.WithOrigins(
-                "http://localhost:4200",
-                "https://dev.devforabuck.com",
-                "https://www.devforabuck.com")
+        policy
+            .AllowAnyOrigin()
             .AllowAnyHeader()
-            .AllowAnyMethod();
-    });
+            .AllowAnyMethod());
 });
 
 


### PR DESCRIPTION
## Summary
- allow all origins by setting `AllowAnyOrigin` in CORS policy

## Testing
- ❌ `dotnet build DevForABuck.sln` *(dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acb6cec018832cb6bc8a29014d0709